### PR TITLE
[AST2-204] Measure list

### DIFF
--- a/src/client/components/measure-list/measure-list.vue
+++ b/src/client/components/measure-list/measure-list.vue
@@ -189,6 +189,7 @@ export default {
       const searchFiltered = list => list
         .filter(measure => measure[selectedType] === true || showAll)
         .filter(measure => measure.title.match(searchRE))
+        .filter(measure => measure.measureId !== '0')
 
       return searchFiltered(this.featureSorted)
     },


### PR DESCRIPTION
When a measure with id of 0 shown, it is an error. Logging should be
available which measure was intended to load in the console. The user
should not be bugged with seeing this though