### PR TITLE
prevent from routing to wrong view while actively drawing project area

### DIFF
--- a/src/client/store/selectedAreas.js
+++ b/src/client/store/selectedAreas.js
@@ -29,7 +29,11 @@ export const actions = {
       this.$router.push({ path: `/${rootState.i18n.locale}/project/areas/` }).catch(() => {})
     }
 
-    if (!features.length && !rootGetters['flow/isNewProjectView']) {
+    // Checking when ON the 'new project' view, but also when routing away from it,
+    // in which case the view might already be passed on to the 'settings' route
+    const isOnOrRoutingFromNewProjectView = rootGetters['flow/isNewProjectView'] || rootGetters['flow/isSettingsView']
+
+    if (!features.length && !isOnOrRoutingFromNewProjectView) {
       this.$router.push({ path: `/${rootState.i18n.locale}/project/` }).catch(() => {})
     }
   },


### PR DESCRIPTION
@petergoes it was quite the scavenger hunt, but I think this one line fixed it.
What was happening was, if you go back to edit the project area, while editing the area, there would be a conflict of interest. When clicking 'next' while still editing the area, there would be two things happening:
1. the next button wants to route to /settings/project-area
2. the map would emit an event that it is finished editing the area, and that would trigger a change in `selectedAreas/changeSelection`, where under certain conditions also routing happens.

The second bit of routing would be prevented as long as you're still on the '/new-project' page, but the route has actually already changed to '/settings/project' view by the next button, so the checks in the `selectedAreas/changeSelection` action cannot be trusted anymore.

I fixed this by checking for both 'new project view' and 'settings view'. This works, but may be you can come up with something more robust.