### PR TITLE
[AST-2 270] Project does not load unknown scenario name

### DIFF
--- a/src/client/components/select-input/select-input.vue
+++ b/src/client/components/select-input/select-input.vue
@@ -25,7 +25,7 @@ export default {
   props: {
     value: {
       type: String,
-      required: true,
+      default: null,
     },
     options: {
       type: Array,

--- a/src/client/store/data/workspaces.js
+++ b/src/client/store/data/workspaces.js
@@ -1,5 +1,6 @@
 import Vue from 'vue'
 import getData from '../../lib/get-data'
+import log from '../../lib/log'
 import kebabCase from 'lodash/kebabCase'
 import unset from 'lodash/unset'
 
@@ -28,6 +29,7 @@ export const mutations = {
       ? defaultDomain
       : domain
 
+    log.info(domainName)
     Vue.set(state, '_domain', domainName)
   },
 }

--- a/src/client/store/project.js
+++ b/src/client/store/project.js
@@ -528,7 +528,35 @@ export const actions = {
 
     loadedProject.settings.general.title = name.replace('.json', '')
 
-    if (validProject.valid) {
+    commit('appMenu/hideMenu', null, { root: true })
+
+    let recoveredFromError = false
+    if (!validProject.valid) {
+      let shouldTrowError = true
+
+      // Provided scenario name is not available.
+      // Remove user-provided and notify user
+      if (validProject.errors.length === 1) {
+        const error = validProject.errors[0]
+        if (error.property === 'instance.settings.projectArea.scenarioName' && /is\snot\sone\sof\senum\svalues/.test(error.message)) {
+          loadedProject.settings.projectArea.scenarioName = null
+          shouldTrowError = false
+          recoveredFromError = true
+          dispatch(
+            'notifications/showWarning',
+            { message: this.app.i18n.t('error_scenario_name_reset'), duration: 0 },
+            { root: true },
+          )
+        }
+      }
+
+      if (shouldTrowError) {
+        log.error('Invalid project', validProject.errors)
+        throw new Error('Invalid project')
+      }
+    }
+
+    if (validProject.valid || recoveredFromError) {
       commit('import', loadedProject)
       dispatch('updateMeasuresRanking')
 
@@ -548,13 +576,6 @@ export const actions = {
           { root: true },
         )
       }
-    }
-
-    commit('appMenu/hideMenu', null, { root: true })
-
-    if (!validProject.valid) {
-      log.error('Invalid project', validProject.errors)
-      throw new Error('Invalid project')
     }
   },
   saveProject({ state, rootGetters, commit }) {


### PR DESCRIPTION
When a scenario name is removed from a workspace, we need to handle
cases where a user might have that name saved in a project.
In this case, we remove the scenarioName option from the loaded project.
This will cause the app to return to the settings page with an empty
scenario name
We also notify the user that this has happend