### PR TITLE
[feat] Deal-with project validation error

### DIFF
--- a/src/client/store/project.js
+++ b/src/client/store/project.js
@@ -551,6 +551,10 @@ export const actions = {
         }
       }
 
+      // The server has a different set of kpi's than project. This happens
+      // mostly when kpis change server side (adding for instance). The rest of
+      // the code should deal with these inconsistencies.
+      // There for, we only notify on the console instead of using a notification
       if (validProject.errors.length === 1) {
         const error = validProject.errors[0]
         if (/instance\.settings\.targets\.(climate|cost|waterquality)\srequires\sproperty/.test(error.stack)) {
@@ -558,7 +562,7 @@ export const actions = {
           recoveredFromError = true
           log.warning(
             'Loaded project kpi\'s did not match with server expectations',
-            'Result calculation is not reliable!',
+            'Result of the calculations might not be reliable!',
             { error },
           )
         }

--- a/src/client/store/project.js
+++ b/src/client/store/project.js
@@ -551,6 +551,19 @@ export const actions = {
         }
       }
 
+      if (validProject.errors.length === 1) {
+        const error = validProject.errors[0]
+        if (/instance\.settings\.targets\.(climate|cost|waterquality)\srequires\sproperty/.test(error.stack)) {
+          shouldTrowError = false
+          recoveredFromError = true
+          log.warning(
+            'Loaded project kpi\'s did not match with server expectations',
+            'Result calculation is not reliable!',
+            { error },
+          )
+        }
+      }
+
       if (shouldTrowError) {
         log.error('Invalid project', validProject.errors)
         throw new Error('Invalid project')

--- a/src/schemas/area-schema.js
+++ b/src/schemas/area-schema.js
@@ -19,7 +19,7 @@ const propertiesSchema = kpiGroups => ({
     isProjectArea: { type: 'boolean' },
     apiData: {
       type: 'object',
-      additionalProperties: false,
+      additionalProperties: true,
       properties: Object.keys(kpiGroups)
       .map(groupKey => kpiGroups[groupKey].kpis.map(kpi => kpi.key))
       .reduce((groupObject, keys) => ({

--- a/src/schemas/settings-schema.js
+++ b/src/schemas/settings-schema.js
@@ -22,7 +22,7 @@ function addAreaProperty(obj, item) {
 function addKpiProperty(obj, item) {
   obj[item.key] = {
     type: 'object',
-    additionalProperties: false,
+    additionalProperties: true,
     required: item.kpis.map(kpi => kpi.key),
     properties: item.kpis.reduce((propObj, kpi) => ({
       ...propObj,


### PR DESCRIPTION
Now the project validation is very tight. Meaning that if the project
kpis do not match. The project won't load. But that also means that the
server can not change without invalidating all previously saved
projects.

This PR loosens the validation. It logs to the console that the results
are not reliable. When this happens, the server should update as quickly
as possible