### PR TITLE
Allow creation of measure from measure details view

### DIFF
--- a/src/client/pages/project/measures/_slug.vue
+++ b/src/client/pages/project/measures/_slug.vue
@@ -2,7 +2,6 @@
   <div class="measure">
     <back-button class="measure__top" comp="div">
       <md-button
-        :disabled="!selectedFeatures.length"
         class="md-raised md-accent"
         @click="() => onChoose(measure)"
       >
@@ -61,9 +60,20 @@ export default {
   },
   methods: {
     ...mapActions({ setAreaMeasure: 'project/setAreaMeasure' }),
+    ...mapActions({
+      chooseMeasure: 'setMeasureFlow/chooseMeasure',
+      startFlow: 'setMeasureFlow/startFlow',
+    }),
     onChoose(measure) {
-      this.setAreaMeasure({ features: this.selectedFeatures, measure })
-      this.$router.push(`/${this.$i18n.locale}/project/areas/`).catch(() => {})
+      if (this.selectedFeatures.length) {
+        // set measure to selected features
+        this.setAreaMeasure({ features: this.selectedFeatures, measure })
+        this.$router.push(`/${this.$i18n.locale}/project/areas/`).catch(() => {})
+      } else {
+        // go to drawing mode in set-measure-flow
+        this.startFlow()
+        this.chooseMeasure(measure.measureId)
+      }
     },
     back() {
       this.$router.back()

--- a/src/client/pages/set-measure.vue
+++ b/src/client/pages/set-measure.vue
@@ -32,7 +32,9 @@ export default {
     ...mapGetters('setMeasureFlow', ['activeStep']),
   },
   mounted() {
-    this.startFlow()
+    if (!this.currentStep) {
+      this.startFlow()
+    }
   },
   destroyed() {
     this.resetFlow({ relocate: false })


### PR DESCRIPTION
When creating a new Measure from the "+ Measure" button, the "Choose" button on the detail view of Measures from the list is disabled. This is because that view was meant to be used when the Feature (line, marker, polygon) has been drawn and the Measure is replaced. 

With this change the "Choose" button on the detail view can now deeplink into the flow where Measures are selected first.