### PR TITLE
Feat/measure actor

### DIFF
--- a/src/client/components/area-property-radio/area-property-radio.vue
+++ b/src/client/components/area-property-radio/area-property-radio.vue
@@ -1,0 +1,92 @@
+<template>
+  <fieldset>
+    <legend class="area-property-radio__label">
+      {{ $t(`area_${valueTypeLower}`) }}
+      <app-tooltip
+        :message="$t(`area_${ valueTypeLower }_info`)"
+        class="area-property-radio__info"
+        direction="left"
+      />
+    </legend>
+    <md-radio
+      v-for="option in options"
+      :key="option"
+      v-model="internalValue"
+      :name="valueType"
+      :value="option"
+      @change="update(option)"
+    >
+      {{ $t(`area_${ valueTypeLower }_${option}`) }}
+    </md-radio>
+  </fieldset>
+</template>
+
+<script>
+import AppTooltip from '@/components/app-tooltip'
+
+export default {
+  components: {
+    AppTooltip,
+  },
+  props: {
+    valueType: {
+      type: String,
+      required: true,
+    },
+    value: {
+      type: String,
+      required: true,
+    },
+    options: {
+      type: Array,
+      required: true,
+    },
+  },
+  data: () => ({
+    internalValue: null,
+  }),
+  computed: {
+    valueTypeLower() {
+      return this.valueType.toLowerCase()
+    },
+  },
+  watch: {
+    value(newVal, oldVal) {
+      if(newVal === oldVal) return
+      this.updateInternal()
+    },
+  },
+  created() {
+    this.updateInternal()
+  },
+  methods: {
+    updateInternal() {
+      this.internalValue = this.value
+    },
+    update(value) {
+      this.$emit('change', {
+        key: this.valueType,
+        value,
+      })
+    },
+  },
+}
+</script>
+
+<style>
+.aoperty-radio:focus-within .area-property-radio__label {
+  color: var(--md-theme-default-primary);
+}
+
+.area-property-radio__label {
+  position: relative;
+  display: block;
+  font-size: var(--font-size-extra-small);
+  color: rgba(0,0,0,0.54);
+}
+.area-property-radio__info {
+  position: absolute;
+  top: -9px;
+  right: -40px;
+}
+</style>

--- a/src/client/components/area-property-radio/index.js
+++ b/src/client/components/area-property-radio/index.js
@@ -1,0 +1,2 @@
+import Component from './area-property-radio.vue'
+export default Component

--- a/src/client/components/kpi-table/kpi-table.vue
+++ b/src/client/components/kpi-table/kpi-table.vue
@@ -25,14 +25,25 @@
           </md-table-head>
         </md-table-row>
 
-        <template v-if="table.rows">
+        <template v-for="(header, i) in table.rowSetHeaders">
           <md-table-row
-            v-for="(row, index) in table.rows"
-            :key="index"
+            v-if="table.rowSetHeaders.length > 1"
+            :key="`row-heading-${header}`"
+          >
+            <md-table-head
+              :colspan="table.header.length"
+              scope="colgroup"
+            >
+              {{ $t(`area_actor_${header}`) }}
+            </md-table-head>
+          </md-table-row>
+          <md-table-row
+            v-for="(row, j) in table.rowSets[i]"
+            :key="`row-${i}-${j}`"
           >
             <md-table-cell
-              v-for="(value, rowIndex) in row"
-              :key="rowIndex"
+              v-for="(value, k) in row"
+              :key="`cell-${i}-${j}-${k}`"
             >
               {{ value }}
             </md-table-cell>

--- a/src/client/lib/area-actors.js
+++ b/src/client/lib/area-actors.js
@@ -1,0 +1,2 @@
+export const ACTORS = ['public', 'private']
+export const DEFAULT_ACTOR = 'public'

--- a/src/client/pages/project/areas.vue
+++ b/src/client/pages/project/areas.vue
@@ -68,7 +68,7 @@
               </div>
             </div>
 
-            <template v-if="selectedMeasure">
+            <template v-if="selectedMeasureId && selectedMeasure">
               <area-property-radio
                 :value="actor"
                 :options="ACTORS"

--- a/src/client/store/project.js
+++ b/src/client/store/project.js
@@ -840,13 +840,15 @@ export const getters = {
         : value
 
       const measureValueMap = getters.areas
-        .filter(area => area.properties.hasOwnProperty('measure'))
-        .map(area => {
-          const values = kpiKeys.map(key => get(area, `properties.apiData[${key}]`))
-          return [area.properties.measure, area.properties.area, ...values]
-        })
-        .reduce((obj, row) => {
-          const [measureId, ...values] = row
+        .reduce((obj, area) => {
+          if (!area.properties.hasOwnProperty('measure')) return obj
+
+          const measureId = area.properties.measure
+          const values = [
+            area.properties.area,
+            ...kpiKeys.map(key => get(area, `properties.apiData[${key}]`)),
+          ]
+
           if (obj[measureId] === undefined) {
             obj[measureId] = values
           } else {
@@ -859,16 +861,15 @@ export const getters = {
               obj[measureId][index] += value
             })
           }
+
+          const A_tot = state.settings.area.properties.area
+          const A_p = state.settings.pluvfloodParam.A_p
+          const Frac_RA = state.settings.pluvfloodParam.Frac_RA
+          const Fmeas_area = calculateFmeasArea(A_tot, A_p, Frac_RA, obj[measureId][2])
+          obj[measureId][2] = Fmeas_area
+
           return obj
         }, {})
-
-      Object.keys(measureValueMap).forEach(key => {
-        const A_tot = state.settings.area.properties.area
-        const A_p = state.settings.pluvfloodParam.A_p
-        const Frac_RA = state.settings.pluvfloodParam.Frac_RA
-        const Fmeas_area = calculateFmeasArea(A_tot, A_p, Frac_RA, measureValueMap[key][2])
-        measureValueMap[key][2] = Fmeas_area
-      })
 
       return {
         'title': rootState.i18n.messages.climate_and_costs,
@@ -919,20 +920,18 @@ export const getters = {
         : value
 
       const measureValueMap = getters.areas
-        .filter(area => area.properties.hasOwnProperty('measure'))
-        .map(area => {
-          const values = kpiKeys.map(key =>
-            get(area, `properties.apiData[${key}]`),
-          )
-          return [area.properties.measure, area.properties.area, ...values]
-        })
-        .reduce((obj, row) => {
-          const [measureId, ...values] = row
+        .reduce((obj, area) => {
+          if (!area.properties.hasOwnProperty('measure')) return obj
+
+          const measureId = area.properties.measure
+          const values = [area.properties.area, ...kpiKeys.map(key => get(area, `properties.apiData[${key}]`))]
+
           if (obj[measureId] === undefined) {
             obj[measureId] = values
           } else {
             values.forEach((value, index) => (obj[measureId][index] += value))
           }
+
           return obj
         }, {})
 


### PR DESCRIPTION
Adds the option to specify if the responsible or acting party related to the feature (with measure) is either public or private. 
This is then visible in the table view by displaying a row between the entries:
<img width="724" alt="image" src="https://github.com/user-attachments/assets/23e9dd47-9fb2-4e8e-ada4-f8f38e8eb54f">

Note that the first set of rows are unlabeled (neither public nor private) entries. Additionally, when there is only one type of actor specified for all features, the headers are skipped.