### PR TITLE
Feat/skip project config

### DIFF
--- a/config/data/_workspace.graphql
+++ b/config/data/_workspace.graphql
@@ -11,6 +11,7 @@ query ($locale: SiteLocale, $id: ItemId){
     accentColor {
       hex
     }
+    skipAreaSettings,
     excludeAllMeasures,
     showRivmCoBenefits,
     showHeatstress,

--- a/src/client/components/measure-list/measure-list.vue
+++ b/src/client/components/measure-list/measure-list.vue
@@ -76,6 +76,7 @@
             </svg>
           </md-button>
           <md-button
+            v-if="hasSuitabilityRankings"
             :class="{'md-accent': sortType === SYSTEM_SUITABILITY}"
             class="md-icon-button"
             @click="sortType = SYSTEM_SUITABILITY"
@@ -157,7 +158,7 @@ export default {
     SYSTEM_SUITABILITY,
     ALPHA,
     searchValue: '',
-    sortType: SYSTEM_SUITABILITY,
+    sortType: ALPHA,
     sorting: ['featured'],
   }),
   computed: {
@@ -178,6 +179,10 @@ export default {
         return 0
       })
       return [...sorted, ...withoutSuitablility]
+    },
+    hasSuitabilityRankings() {
+      // If the first measure does not have a systemSuitability value, then none of them do
+      return !isNaN(Number(this.measures[0].systemSuitability))
     },
     alphaSortedMeasures() {
       return [...this.measures].sort((a, b) => {
@@ -229,6 +234,11 @@ export default {
 
       return searchFiltered(this.featureSorted)
     },
+  },
+  mounted() {
+    if (this.hasSuitabilityRankings) {
+      this.sortType = SYSTEM_SUITABILITY
+    }
   },
   methods: {
     choose(value) {

--- a/src/client/pages/settings/project-area.vue
+++ b/src/client/pages/settings/project-area.vue
@@ -138,7 +138,7 @@ export default {
     }),
     ...mapGetters({
       projectAreaSettings: 'project/settingsProjectArea',
-      areaSettings: 'data/areaSettings/overriddenAreaSettings',
+      areaSettings: 'data/areaSettings/requiredAreaSettings',
       scenariosInActiveWorkspace: 'data/workspaces/scenariosInActiveWorkspace',
       activeWorkspace: 'data/workspaces/activeWorkspace',
     }),

--- a/src/client/store/data/areaSettings.js
+++ b/src/client/store/data/areaSettings.js
@@ -18,8 +18,25 @@ export const actions = {
 }
 
 export const getters = {
+  requiredAreaSettings(state, getters, rootState, rootGetters) {
+    const overriddenAreaSettings = getters.overriddenAreaSettings
+    const skipAreaSettings = rootGetters['data/workspaces/skipAreaSettings']
+
+    const scenarioNameSetting = overriddenAreaSettings.find(({ key }) => key === 'scenarioName');
+
+    if (skipAreaSettings) {
+      return [scenarioNameSetting]
+    }
+
+    return overriddenAreaSettings
+  },
   overriddenAreaSettings(state, getters, rootState, rootGetters) {
     const activeWorkspace = rootGetters['data/workspaces/activeWorkspace']
+
+    if (!activeWorkspace) {
+      return state
+    }
+
     return state.map(item => {
       const { options, defaultValue, ...itemRest } = item
       const { key } = itemRest

--- a/src/client/store/data/workspaces.js
+++ b/src/client/store/data/workspaces.js
@@ -91,4 +91,16 @@ export const getters = {
       .filter(({ value }) => Boolean(rootState.data.scenarios.find(scenario => scenario.value === value)))
       .map(({ value }) => rootState.data.scenarios.find(scenario => scenario.value === value))
   },
+  skipAreaSettings(state) {
+    const activeDomain = state._domain
+    const activeUser = state._user
+    const activeName = activeUser || activeDomain
+    const workspace = state[activeName]
+
+    let skipAreaSettings = false
+    if (workspace) {
+      skipAreaSettings = workspace.skipAreaSettings || skipAreaSettings
+    }
+    return skipAreaSettings
+  },
 }

--- a/src/client/store/flow.js
+++ b/src/client/store/flow.js
@@ -1,5 +1,4 @@
 import get from 'lodash/get'
-import isObject from 'lodash/isObject'
 import getViewPath from '../lib/get-view-path'
 import isValidNumber from '../lib/is-valid-number'
 import log from '../lib/log'
@@ -70,13 +69,13 @@ export const getters = {
   createdProjectArea(state, getters, rootState) {
     return !!rootState.project.settings.area.properties && getters.projectAreaSizeIsBelowThreshold
   },
-  filledInRequiredProjectAreaSettings(state, getters, rootState) {
+  filledInRequiredProjectAreaSettings(state, getters, rootState, rootGetters) {
     const { A_p, Frac_RA } = rootState.project.settings.pluvfloodParam
     const projectArea = rootState.project.settings.projectArea
+    const requiredAreaSettings = rootGetters['data/areaSettings/requiredAreaSettings'];
 
-    const settingsFilledIn = !Object.keys(projectArea)
-      .filter(setting => !isObject(projectArea[setting]))
-      .map(key => projectArea[key])
+    let settingsFilledIn = 0 === requiredAreaSettings
+      .map(({ key }) => projectArea[key])
       .filter(value => value === null)
       .length
 

--- a/src/client/store/project.js
+++ b/src/client/store/project.js
@@ -572,9 +572,10 @@ export const actions = {
   },
   async updateMeasuresRanking({ state, commit, rootGetters, dispatch }) {
     const filledInRequiredProjectAreaSettings = rootGetters['flow/filledInRequiredProjectAreaSettings']
+    const skipAreaSettings = rootGetters['data/workspaces/skipAreaSettings']
+    const { projectArea } = state.settings;
 
-    if (filledInRequiredProjectAreaSettings) {
-      const { projectArea } = state.settings
+    if (!skipAreaSettings && filledInRequiredProjectAreaSettings) {
       getRankedMeasures(projectArea)
         .then(rankedMeasures =>
           commit('data/measures/addMeasuresRanking', rankedMeasures, { root: true }),


### PR DESCRIPTION
* Added a setting to workspaces in DATO to skip all project area settings, except for the scenario.
* Without those settings a suitability ranking of measures cannot be determined, therefore it isn't fetched from the API.
* The button to sort measures based on suitability is removed and the default sorting is set to alphabetically.