### PR TITLE
Fix Dato plugins by referring to files on unpkg

### DIFF
--- a/src/client/static/dato-plugins/key-value-pairs/index.html
+++ b/src/client/static/dato-plugins/key-value-pairs/index.html
@@ -6,8 +6,8 @@
 <title>Key/Value pairs</title>
 <script src="https://cdn.jsdelivr.net/npm/lodash@4.17.15/lodash.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.js"></script>
-<script src="https://unpkg.com/datocms-plugins-sdk"></script>
-<script src="https://unpkg.com/datocms-client"></script>
+<script src="https://unpkg.com/datocms-plugins-sdk/dist/sdk.js"></script>
+<script src="https://unpkg.com/datocms-client/dist/client.js"></script>
 <link href="https://unpkg.com/datocms-plugins-sdk/dist/sdk.css" media="all" rel="stylesheet" />
 
 <div class="app" id="app">

--- a/src/client/static/dato-plugins/measure-overrides/index.html
+++ b/src/client/static/dato-plugins/measure-overrides/index.html
@@ -6,8 +6,8 @@
 <title>Measure Override</title>
 <script src="https://cdn.jsdelivr.net/npm/lodash@4.17.15/lodash.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.js"></script>
-<script src="https://unpkg.com/datocms-plugins-sdk"></script>
-<script src="https://unpkg.com/datocms-client"></script>
+<script src="https://unpkg.com/datocms-plugins-sdk/dist/sdk.js"></script>
+<script src="https://unpkg.com/datocms-client/dist/client.js"></script>
 <script src="utils.js"></script>
 <script type="module" src="upload-image.js"></script>
 <script type="module" src="text-input.js"></script>


### PR DESCRIPTION
Unpkg used to look for the `browser` property in the `package.json` and serve that file when importing from the package name. Unfortunately that no longer works. Importing the file by actual path resolves this. 

An even better solution would be bundling the dependencies instead of relying on unpkg, but that would be more involved.